### PR TITLE
go: fix import paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ release-snapshot:
 	goreleaser --rm-dist --skip-publish --snapshot
 
 test:
-	go test -cover -coverprofile=coverage.out  whatsthis/pkg/...
+	go test -cover -coverprofile=coverage.out  ./...
 
 test-coverage: test
 	go tool cover -html=coverage.out

--- a/alias.go
+++ b/alias.go
@@ -1,15 +1,15 @@
 package whatsthis
 
 import (
-	"whatsthis/pkg/cloud"
-	"whatsthis/pkg/container"
-	"whatsthis/pkg/cpu"
-	"whatsthis/pkg/distro"
-	"whatsthis/pkg/memory"
-	"whatsthis/pkg/network"
-	"whatsthis/pkg/platform"
-	"whatsthis/pkg/storage"
-	"whatsthis/pkg/virt"
+	"github.com/powersj/whatsthis/pkg/cloud"
+	"github.com/powersj/whatsthis/pkg/container"
+	"github.com/powersj/whatsthis/pkg/cpu"
+	"github.com/powersj/whatsthis/pkg/distro"
+	"github.com/powersj/whatsthis/pkg/memory"
+	"github.com/powersj/whatsthis/pkg/network"
+	"github.com/powersj/whatsthis/pkg/platform"
+	"github.com/powersj/whatsthis/pkg/storage"
+	"github.com/powersj/whatsthis/pkg/virt"
 )
 
 // CloudProbe alias for cloud.Probe

--- a/cmd/whatsthis/cmd/cloud.go
+++ b/cmd/whatsthis/cmd/cloud.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/container.go
+++ b/cmd/whatsthis/cmd/container.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/cpu.go
+++ b/cmd/whatsthis/cmd/cpu.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/distro.go
+++ b/cmd/whatsthis/cmd/distro.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/memory.go
+++ b/cmd/whatsthis/cmd/memory.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/network.go
+++ b/cmd/whatsthis/cmd/network.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/platform.go
+++ b/cmd/whatsthis/cmd/platform.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/root.go
+++ b/cmd/whatsthis/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"whatsthis/internal/file"
-	"whatsthis/internal/system"
+	"github.com/powersj/whatsthis/internal/file"
+	"github.com/powersj/whatsthis/internal/system"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/cmd/whatsthis/cmd/storage.go
+++ b/cmd/whatsthis/cmd/storage.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/cmd/virt.go
+++ b/cmd/whatsthis/cmd/virt.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"whatsthis"
+
+	"github.com/powersj/whatsthis"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/whatsthis/main.go
+++ b/cmd/whatsthis/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"runtime"
 
-	cmd "whatsthis/cmd/whatsthis/cmd"
+	cmd "github.com/powersj/whatsthis/cmd/whatsthis/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module whatsthis
+module github.com/powersj/whatsthis
 
 go 1.14
 

--- a/internal/cpuid/cpuid.go
+++ b/internal/cpuid/cpuid.go
@@ -3,7 +3,7 @@ package cpuid
 import (
 	"bytes"
 
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for cpuid.

--- a/internal/filesystem/etc.go
+++ b/internal/filesystem/etc.go
@@ -1,7 +1,7 @@
 package filesystem
 
 import (
-	"whatsthis/internal/file"
+	"github.com/powersj/whatsthis/internal/file"
 )
 
 // Etc represents the /etc filesystem

--- a/internal/filesystem/proc.go
+++ b/internal/filesystem/proc.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"whatsthis/internal/file"
+	"github.com/powersj/whatsthis/internal/file"
 )
 
 // Proc represents the /proc filesystem

--- a/internal/filesystem/run.go
+++ b/internal/filesystem/run.go
@@ -1,7 +1,7 @@
 package filesystem
 
 import (
-	"whatsthis/internal/file"
+	"github.com/powersj/whatsthis/internal/file"
 )
 
 // Run represents the /run filesystem

--- a/internal/filesystem/sys.go
+++ b/internal/filesystem/sys.go
@@ -3,8 +3,8 @@ package filesystem
 import (
 	"path"
 
-	"whatsthis/internal/file"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/file"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Sys represents the /sys filesystem

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -3,16 +3,16 @@ package system
 import (
 	"fmt"
 
-	"whatsthis/internal/util"
-	"whatsthis/pkg/cloud"
-	"whatsthis/pkg/container"
-	"whatsthis/pkg/cpu"
-	"whatsthis/pkg/distro"
-	"whatsthis/pkg/memory"
-	"whatsthis/pkg/network"
-	"whatsthis/pkg/platform"
-	"whatsthis/pkg/storage"
-	"whatsthis/pkg/virt"
+	"github.com/powersj/whatsthis/internal/util"
+	"github.com/powersj/whatsthis/pkg/cloud"
+	"github.com/powersj/whatsthis/pkg/container"
+	"github.com/powersj/whatsthis/pkg/cpu"
+	"github.com/powersj/whatsthis/pkg/distro"
+	"github.com/powersj/whatsthis/pkg/memory"
+	"github.com/powersj/whatsthis/pkg/network"
+	"github.com/powersj/whatsthis/pkg/platform"
+	"github.com/powersj/whatsthis/pkg/storage"
+	"github.com/powersj/whatsthis/pkg/virt"
 )
 
 // System struct for all probes we want to report at once.

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for clouds. Used to store the results of the probe and the

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for containres. Used to store the results of the probe and the

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for CPUs.

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for distro.

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -3,9 +3,9 @@ package memory
 import (
 	"fmt"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/units"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/units"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for memory.

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -6,8 +6,8 @@ import (
 	"path"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for storage. Splits adapters by physical adapters, virtual

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3,8 +3,8 @@ package platform
 import (
 	"fmt"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for platform. Captures the BIOS and Board values.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"whatsthis/internal/filesystem"
-	"whatsthis/internal/units"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/filesystem"
+	"github.com/powersj/whatsthis/internal/units"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for storage. Captures disks, which capture partitions.

--- a/pkg/virt/virt.go
+++ b/pkg/virt/virt.go
@@ -3,8 +3,8 @@ package virt
 import (
 	"fmt"
 
-	"whatsthis/internal/cpuid"
-	"whatsthis/internal/util"
+	"github.com/powersj/whatsthis/internal/cpuid"
+	"github.com/powersj/whatsthis/internal/util"
 )
 
 // Probe struct for virt. Used to store the results of the probe and the


### PR DESCRIPTION
When trying to go get the application, the import paths were not
correctly prefaced with "github.com/powersj/". This fixes this and
updates the go.mod file with the full module name.